### PR TITLE
issue #37: fixing Get-SFTPFile/Set-SFTPFile fail with 'Object reference not set to an instance of an object.'

### DIFF
--- a/PoshSSH/PoshSSH/GetSftpFile.cs
+++ b/PoshSSH/PoshSSH/GetSftpFile.cs
@@ -95,7 +95,9 @@ namespace SSH
             switch (ParameterSetName)
             {
                 case "Session":
-                    ToProcess.AddRange(_session);
+                    // fix issue #37: Get-SFTPFile/Set-SFTPFile fail with 'Object reference not set to an instance of an object.'
+                    toProcess.AddRange(_session);
+                    ToProcess = toProcess;
                     break;
                 case "Index":
                     if (sessionvar != null)

--- a/PoshSSH/PoshSSH/SetSftpFile.cs
+++ b/PoshSSH/PoshSSH/SetSftpFile.cs
@@ -95,7 +95,9 @@ namespace SSH
             switch (ParameterSetName)
             {
                 case "Session":
-                    ToProcess.AddRange(_session);
+                    // fix issue #37: Get-SFTPFile/Set-SFTPFile fail with 'Object reference not set to an instance of an object.'
+                    toProcess.AddRange(_session);
+                    ToProcess = toProcess;
                     break;
                 case "Index":
                     if (sessionvar != null)


### PR DESCRIPTION
Fixes issue #37: Get-SFTPFile/Set-SFTPFile fail with 'Object reference not set to an instance of an object.' when called with SFTPSession.