### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ iex (New-Object Net.WebClient).DownloadString("https://gist.github.com/darkopera
 
 # ChangeLog
 ## Version 1.7.2
-* Fix problem with Get-SFTPFile cmdlet. It was creating a empty file before checking if a file existed causing error or blanking a exiting file accidentaly.
+* Fix problem with Get-SFTPFile cmdlet. It was creating a empty file before checking if a file existed causing error or blanking a exiting file accidentally.
 - Add session and session id properties to a generated streem to address request in issue #34
 
 ## Version 1.7.1


### PR DESCRIPTION
darkoperator, I've corrected a typographical error in the documentation of the [Posh-SSH](https://github.com/darkoperator/Posh-SSH) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.