### PR TITLE
Fixed a typo in the Invoke-SSHStreamExpectSecureAction documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ x86_64 x86_64 GNU/Linux
 * New function **Invoke-SSHStreamExpectSecureAction **for passing passwords to prompt on a shell stream.
 
 ```PowerShell
-C:\PS>Invoke-SSHStreamExpectSecureAction -ShellStream $stream -Command 'su -' -ExpectString 'Passord:' -SecureAction (read-host -AsSecureString) -Verbose
+C:\PS>Invoke-SSHStreamExpectSecureAction -ShellStream $stream -Command 'su -' -ExpectString 'Password:' -SecureAction (read-host -AsSecureString) -Verbose
 
 ***********
 VERBOSE: Executing command su -.


### PR DESCRIPTION
I have fixed a small (but significant) typo in the example Invoke-SSHStreamExpectSecureAction cmdlet usage. See the Readme.md