### PR TITLE
Throw a proper exception when creating new directory with -Recurse option

### DIFF
--- a/Sftp.ps1
+++ b/Sftp.ps1
@@ -1487,12 +1487,7 @@ function New-SFTPItem
                                     }
                                 } else {
                                     Write-Verbose -Message "Creating $($newPath)"
-                                    try {
-                                        $sess.Session.CreateDirectory($newPath)
-                                    } catch {
-                                        $_
-                                        $return
-                                    }
+                                    $sess.Session.CreateDirectory($newPath)
                                 }
                             }
                             $sess.Session.Get($Path)


### PR DESCRIPTION
Throws a proper exception when creating new directory with -Recurse option.

When user doesn't have a permissions to create directory in specified location an information about that was missing and code was throwing the error below:

```
Exception Message: System.Management.Automation.MethodInvocationException:
Exception calling "Get" with "1" argument(s): 
"No such file" ---> Renci.SshNet.Common.SftpPathNotFoundException: No such file
```

Now code is throwing the proper exception as the same as for creation of new directory without -Recurse flag:

```
Exception Message: System.Management.Automation.MethodInvocationException: 
Exception calling "CreateDirectory" with "1" argument(s): 
"Permission denied" ---> Renci.SshNet.Common.SftpPermissionDeniedException: Permission denied
```