### PR TITLE
V2 0 2 - Updating Trust.ps1 to allow multiple fingerprints for a host.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Version 2.0.2
+
+* Set-SFTPContent will no longer add a BOM to UTF8 encoded files.
+* Fixed issue with path resolution in Get-SCPFile.
+* Fixed typo in New-SFTPSymlink.
+
 ## Version 2.0.1
 
 * Get-SFTPCholdItem was not showinng folders when recursively listing.

--- a/Posh-SSH.psd1
+++ b/Posh-SSH.psd1
@@ -12,7 +12,7 @@
 #RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '2.0.1'
+ModuleVersion = '2.0.2'
 
 
 # ID used to uniquely identify this module

--- a/PoshSSH/PoshSSH/GetScpFile.cs
+++ b/PoshSSH/PoshSSH/GetScpFile.cs
@@ -526,9 +526,8 @@ namespace SSH
                 {
                     if (client.IsConnected)
                     {
-                        ProviderInfo provider;
-                        var pathinfo = GetResolvedProviderPathFromPSPath(_keyfile, out provider);
-                        var localfullPath = pathinfo[0];
+
+                        var localfullPath = this.SessionState.Path.GetUnresolvedProviderPathFromPSPath(_localfile);
 
                         WriteVerbose("Downloading " + _remotefile);
                         WriteVerbose("Saving as " + localfullPath);

--- a/Sftp.ps1
+++ b/Sftp.ps1
@@ -1193,7 +1193,7 @@ function Set-SFTPContent
             }
 
             'UTF8' {
-                $ContentEncoding = [System.Text.Encoding]::UTF8
+                $ContentEncoding = New-Object System.Text.UTF8Encoding $false
             }
 
             'UTF32' {

--- a/Sftp.ps1
+++ b/Sftp.ps1
@@ -932,7 +932,7 @@ function New-SFTPSymlink
         foreach($session in $ToProcess)
         {
             $filepath = Test-SFTPPath -SFTPSession $session -Path $Path
-            $linkstatus = Test-SFTPPath -SFTPSession $session -path $LinkPath`
+            $linkstatus = Test-SFTPPath -SFTPSession $session -path $LinkPath
             if (($filepath) -and (!$linkstatus))
             {
                 try


### PR DESCRIPTION
Suggested update to Trust.ps1 to allow multiple fingerprints to be used for a single host. This update changes the values stored in the registry to be MultiString values, each element is a single fingerprint.