### PR TITLE
$Global:SshSessions type matches C# code

### DIFF
--- a/Posh-SSH.psm1
+++ b/Posh-SSH.psm1
@@ -2,12 +2,12 @@
 ##############################################################################################
 if (!(Test-Path variable:Global:SshSessions ))
 {
-    $global:SshSessions = New-Object System.Collections.ArrayList
+    $global:SshSessions = New-Object -TypeName 'System.Collections.Generic.List[SSH.SshSession]'
 }
 
 if (!(Test-Path variable:Global:SFTPSessions ))
 {
-    $global:SFTPSessions = New-Object System.Collections.ArrayList
+    $global:SFTPSessions = New-Object -TypeName 'System.Collections.Generic.List[SSH.SftpSession]'
 }
 
 # Dot Sourcing of functions


### PR DESCRIPTION
`$global:SshSessions` was ArrayList, but the C# code cast it to Generic.List<SshSession>. 
This fix makes it Generic.List[Ssh.SshSession] from the beginning.
Fixes #171