### PR TITLE
Fix documentation, error message for Set-SFTPFile

### DIFF
--- a/Source/PoshSSH/PoshSSH/SetSftpFile.cs
+++ b/Source/PoshSSH/PoshSSH/SetSftpFile.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using Renci.SshNet.Common;
 using System;
@@ -205,10 +205,10 @@ namespace SSH
                         }
                         else
                         {
-                            var ex = new SftpPathNotFoundException(RemotePath + " does not exist.");
+                            var ex = new SftpPathNotFoundException("Directory " + RemotePath + " does not exist.");
                             WriteError(new ErrorRecord(
                                         ex,
-                                        RemotePath + " does not exist.",
+                                        "Directory " + RemotePath + " does not exist.",
                                         ErrorCategory.InvalidOperation,
                                         sftpSession));
                         }

--- a/docs/Set-SFTPFile.md
+++ b/docs/Set-SFTPFile.md
@@ -51,7 +51,7 @@ Accept wildcard characters: False
 ```
 
 ### -RemotePath
-Remote path where to upload the item to, including its name.
+Remote path of directory to which the item will be uploaded. Should not include the filename nor the trailing slash.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Addresses #116. Changed documentation for `Set-SFTPFile` which erroneously stated the following for the `RemotePath` argument.

> Remote path where to upload the item to, including its name.

When using the `SetSFTPFile` command with `RemotePath` as the intended remote file path (including file name, extension), user was presented with the following error message.

> Set-SFTPFile : /path/to/mfile.ext does not exist.

This was misleading as inspecting the code reveals the `RemotePath` argument is appended with the file name upon invocation of `Set-SFTPFile`. See [relevant line](https://github.com/darkoperator/Posh-SSH/blob/d88c7f216fab438802a08ded2d7c5795b56786d3/Source/PoshSSH/PoshSSH/SetSftpFile.cs#L135).

PR changes documentation and error message.