### PR TITLE
Add cross-platform support

### DIFF
--- a/Source/PoshSSH/PoshSSH/NewSessionBase.cs
+++ b/Source/PoshSSH/PoshSSH/NewSessionBase.cs
@@ -277,7 +277,7 @@ namespace SSH
                         break;
                 }
 
-                //Ceate instance of SSH Client with connection info
+                //Create instance of SSH Client with connection info
                 BaseClient client;
                 if (Protocol == "SSH")
                     client = new SshClient(connectInfo);

--- a/Source/PoshSSH/PoshSSH/PoshSSH.csproj
+++ b/Source/PoshSSH/PoshSSH/PoshSSH.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+<!-- ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" -->
+  <!-- <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" /> -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -9,9 +10,15 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SSH</RootNamespace>
     <AssemblyName>PoshSSH</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <AssemblyTitle>PoshSSH</AssemblyTitle>
+    <Description>Posh-SSH Main module.</Description>
+    <Company>https://wwww.darkoperator.com</Company>
+    <Copyright>Copyright © 2019</Copyright>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +40,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Management.Automation" />
+    <PackageReference Include="SSH.NET" Version="2020.0.0-beta1" />
+  </ItemGroup>
+  <!-- <ItemGroup>
     <Reference Include="Renci.SshNet">
       <HintPath>..\..\..\Release\Assembly\Renci.SshNet.dll</HintPath>
     </Reference>
@@ -47,8 +58,8 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
+  </ItemGroup> -->
+  <!-- <ItemGroup>
     <Compile Include="ConnectionInfoGenerator.cs" />
     <Compile Include="GetScpFile.cs" />
     <Compile Include="GetScpFolder.cs" />
@@ -73,14 +84,14 @@
     <Compile Include="SetScpFile.cs" />
     <Compile Include="SetScpFolder.cs" />
     <Compile Include="TrustedKeyMng.cs" />
-  </ItemGroup>
-  <ItemGroup>
+  </ItemGroup> -->
+  <!-- <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  </ItemGroup> -->
+  <!-- <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" /> -->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/PoshSSH/PoshSSH/Properties/AssemblyInfo.cs
+++ b/Source/PoshSSH/PoshSSH/Properties/AssemblyInfo.cs
@@ -1,15 +1,17 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
+//NOTE: Most of these attributes have been moved to the csproj
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("PoshSSH")]
-[assembly: AssemblyDescription("Posh-SSH Main module.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("https://wwww.darkoperator.com")]
-[assembly: AssemblyProduct("PoshSSH")]
-[assembly: AssemblyCopyright("Copyright © 2019")]
+//[assembly: AssemblyTitle("PoshSSH")]
+//[assembly: AssemblyDescription("Posh-SSH Main module.")]
+//[assembly: AssemblyConfiguration("")]
+//[assembly: AssemblyCompany("https://wwww.darkoperator.com")]
+//[assembly: AssemblyProduct("PoshSSH")]
+//[assembly: AssemblyCopyright("Copyright © 2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+//[assembly: AssemblyVersion("2.1.0.0")]
+//[assembly: AssemblyFileVersion("2.1.0.0")]

--- a/Source/PoshSSH/PoshSSH/TrustedKeyMng.cs
+++ b/Source/PoshSSH/PoshSSH/TrustedKeyMng.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.IO;
 using Microsoft.Win32;
 using System;
 
@@ -7,24 +9,48 @@ namespace SSH
     // Class for managing the keys 
     public class TrustedKeyMng
     {
+        private const string keyFilename = "PoshSSH";
+
         public Dictionary<string, string> GetKeys()
         {
             var hostkeys = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
-            var poshSoftKey = Registry.CurrentUser.OpenSubKey(@"Software\PoshSSH", true);
-            if (poshSoftKey != null)
+            // use the registry to store keys on Windows, and the $HOME path everywhere else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var hosts = poshSoftKey.GetValueNames();
-                foreach (var host in hosts)
+                var poshSoftKey = Registry.CurrentUser.OpenSubKey(@"Software\PoshSSH", true);
+                if (poshSoftKey != null)
                 {
-                    var hostkey = poshSoftKey.GetValue(host).ToString();
-                    hostkeys.Add(host, hostkey);
+                    var hosts = poshSoftKey.GetValueNames();
+                    foreach (var host in hosts)
+                    {
+                        var hostkey = poshSoftKey.GetValue(host).ToString();
+                        hostkeys.Add(host, hostkey);
+                    }
+                }
+                else
+                {
+                    using (var softKey = Registry.CurrentUser.OpenSubKey(@"Software", true))
+                    {
+                        if (softKey != null) softKey.CreateSubKey("PoshSSH");
+                    }
                 }
             }
             else
             {
-                using (var softKey = Registry.CurrentUser.OpenSubKey(@"Software", true))
+                var keyPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                keyPath = Path.Combine(keyPath, ".ssh");
+                keyPath = Path.Combine(keyPath, keyFilename);
+                if (File.Exists(keyPath))
                 {
-                    if (softKey != null) softKey.CreateSubKey("PoshSSH");
+                    foreach (var line in File.ReadLines(keyPath))
+                    {
+                        int separatorIndex = line.IndexOf("=");
+                        if (separatorIndex == -1)
+                        {
+                            continue;
+                        }
+                        hostkeys.Add(line.Substring(0, separatorIndex), line.Substring(separatorIndex + 1));
+                    }
                 }
             }
             return hostkeys;
@@ -32,16 +58,31 @@ namespace SSH
 
         public bool SetKey(string host, string fingerprint)
         {
-            var poshSoftKey = Registry.CurrentUser.OpenSubKey(@"Software\PoshSSH", true);
-            if (poshSoftKey != null)
+            // use the registry to store keys on Windows, and the $HOME path everywhere else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                poshSoftKey.SetValue(host, fingerprint);
-                return true;
+                var poshSoftKey = Registry.CurrentUser.OpenSubKey(@"Software\PoshSSH", true);
+                if (poshSoftKey != null)
+                {
+                    poshSoftKey.SetValue(host, fingerprint);
+                    return true;
+                }
+                var softKey = Registry.CurrentUser.OpenSubKey(@"Software", true);
+                if (softKey == null) return true;
+                softKey.CreateSubKey("PoshSSH");
+                softKey.SetValue(host, fingerprint);
             }
-            var softKey = Registry.CurrentUser.OpenSubKey(@"Software", true);
-            if (softKey == null) return true;
-            softKey.CreateSubKey("PoshSSH");
-            softKey.SetValue(host, fingerprint);
+            else
+            {
+                var keyPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                keyPath = Path.Combine(keyPath, ".ssh");
+                keyPath = Path.Combine(keyPath, keyFilename);
+                if (!File.Exists(keyPath))
+                {
+                    File.Create(keyPath).Dispose();
+                }
+                File.AppendAllText(keyPath, host + "=" + fingerprint + Environment.NewLine);
+            }
             return true;
         }
     }


### PR DESCRIPTION
I am creating this PR mostly to start the discussion on getting Posh-SSH to work cross-platform. The required changes are minimal: for non-Windows machines, just use the .ssh directory for thumbprints. The target framework is set only to netcoreapp3.1, but I'm aware this needs to be changed before the PR can be accepted. Also, this requires the 2020.0.0-beta1 version of the SSH.net library.