### PR TITLE
RemotePathTransformation for [GS]et-SCPItem

### DIFF
--- a/Source/PoshSSH/PoshSSH/GetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/GetScpItem.cs
@@ -80,6 +80,17 @@ namespace SSH
             set { _noProgress = value; }
         }
 
+        private string _pathTransformation;
+        [Parameter(Mandatory = false,
+            ValueFromPipelineByPropertyName = false,
+            HelpMessage = "Remote Path transormation to use.")]
+        [ValidateSet("ShellQuote", "None", "DoubleQuote", IgnoreCase = true)]
+        public string PathTransformation
+        {
+            get { return _pathTransformation; }
+            set { _pathTransformation = value; }
+        }
+
         protected override void ProcessRecord()
         {
             foreach (var computer in ComputerName)
@@ -89,6 +100,18 @@ namespace SSH
                 {
                     if (client != default && client.IsConnected)
                     {
+                        switch (PathTransformation.ToLower())
+                        {
+                            case "shellquote":
+                                client.RemotePathTransformation = RemotePathTransformation.ShellQuote;
+                                break;
+                            case "none":
+                                client.RemotePathTransformation = RemotePathTransformation.None;
+                                break;
+                            case "doublequote":
+                                client.RemotePathTransformation = RemotePathTransformation.DoubleQuote;
+                                break;
+                        }
                         var _progresspreference = (ActionPreference)this.SessionState.PSVariable.GetValue("ProgressPreference");
                         if (_noProgress == false)
                         {

--- a/Source/PoshSSH/PoshSSH/SetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/SetScpItem.cs
@@ -71,6 +71,17 @@ namespace SSH
             set { _noProgress = value; }
         }
 
+        private string _pathTransformation;
+        [Parameter(Mandatory = false,
+            ValueFromPipelineByPropertyName = false,
+            HelpMessage = "Remote Path transormation to use.")]
+        [ValidateSet("ShellQuote", "None", "DoubleQuote", IgnoreCase = true)]
+        public string PathTransformation
+        {
+            get { return _pathTransformation; }
+            set { _pathTransformation = value; }
+        }
+
         protected override void ProcessRecord()
         {
             foreach (var computer in ComputerName)
@@ -80,6 +91,18 @@ namespace SSH
                 {
                     if (client != default && client.IsConnected)
                     {
+                        switch (PathTransformation.ToLower())
+                        {
+                            case "shellquote":
+                                client.RemotePathTransformation = RemotePathTransformation.ShellQuote;
+                                break;
+                            case "none":
+                                client.RemotePathTransformation = RemotePathTransformation.None;
+                                break;
+                            case "doublequote":
+                                client.RemotePathTransformation = RemotePathTransformation.DoubleQuote;
+                                break;
+                        }
                         var _progresspreference = (ActionPreference)this.SessionState.PSVariable.GetValue("ProgressPreference");
                         if (_noProgress == false)
                         {


### PR DESCRIPTION
Added _RemotePathTransformation_ for SCP as `-PathTransformation` option
https://github.com/sshnet/SSH.NET/wiki/ScpClient:-Remote-path-transformation

Not tested, because I have no suitable hosts to use.

By the way, maybe it's time to remove the SCPFile / SCPFolder cmdlets?
I have not added support to them. 