### PR TITLE
Unified and prettified Operation Progress

### DIFF
--- a/Source/PoshSSH/PoshSSH.Core/PoshSSH.Core.csproj
+++ b/Source/PoshSSH/PoshSSH.Core/PoshSSH.Core.csproj
@@ -10,10 +10,7 @@
 
   <ItemGroup>
     <Compile Include="..\PoshSSH\ConnectionInfoGenerator.cs" Link="ConnectionInfoGenerator.cs" />
-    <Compile Include="..\PoshSSH\GetScpFile.cs" Link="GetScpFile.cs" />
-    <Compile Include="..\PoshSSH\GetScpFolder.cs" Link="GetScpFolder.cs" />
     <Compile Include="..\PoshSSH\GetScpItem.cs" Link="GetScpItem.cs" />
-    <Compile Include="..\PoshSSH\GetSftpFile.cs" Link="GetSftpFile.cs" />
     <Compile Include="..\PoshSSH\GetSftpItem.cs" Link="GetSftpItem.cs" />
     <Compile Include="..\PoshSSH\NewSessionBase.cs" Link="NewSessionBase.cs" />
     <Compile Include="..\PoshSSH\NewSftpSession.cs" Link="NewSftpSession.cs" />
@@ -21,11 +18,7 @@
     <Compile Include="..\PoshSSH\OperationProgressHelper.cs" Link="OperationProgressHelper.cs" />
     <Compile Include="..\PoshSSH\PoshSessionType.cs" Link="PoshSessionType.cs" />
     <Compile Include="..\PoshSSH\SessionObject.cs" Link="SessionObject.cs" />
-    <Compile Include="..\PoshSSH\SetScpFile.cs" Link="SetScpFile.cs" />
-    <Compile Include="..\PoshSSH\SetScpFolder.cs" Link="SetScpFolder.cs" />
     <Compile Include="..\PoshSSH\SetScpItem.cs" Link="SetScpItem.cs" />
-    <Compile Include="..\PoshSSH\SetSftpFile.cs" Link="SetSftpFile.cs" />
-    <Compile Include="..\PoshSSH\SetSftpFolder.cs" Link="SetSftpFolder.cs" />
     <Compile Include="..\PoshSSH\SetSftpItem.cs" Link="SetSftpItem.cs" />
     <Compile Include="..\PoshSSH\SshModHelper.cs" Link="SshModHelper.cs" />
 

--- a/Source/PoshSSH/PoshSSH.Core/PoshSSH.Core.csproj
+++ b/Source/PoshSSH/PoshSSH.Core/PoshSSH.Core.csproj
@@ -18,6 +18,7 @@
     <Compile Include="..\PoshSSH\NewSessionBase.cs" Link="NewSessionBase.cs" />
     <Compile Include="..\PoshSSH\NewSftpSession.cs" Link="NewSftpSession.cs" />
     <Compile Include="..\PoshSSH\NewSSHSession.cs" Link="NewSSHSession.cs" />
+    <Compile Include="..\PoshSSH\OperationProgressHelper.cs" Link="OperationProgressHelper.cs" />
     <Compile Include="..\PoshSSH\PoshSessionType.cs" Link="PoshSessionType.cs" />
     <Compile Include="..\PoshSSH\SessionObject.cs" Link="SessionObject.cs" />
     <Compile Include="..\PoshSSH\SetScpFile.cs" Link="SetScpFile.cs" />

--- a/Source/PoshSSH/PoshSSH/GetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/GetScpItem.cs
@@ -141,7 +141,7 @@ namespace SSH
                                 curName = e.Filename;
                                 progressHelper = new OperationProgressHelper(this, "Download", curName, e.Size, 1);
                             }
-                            progressHelper.Callback((ulong)e.Downloaded);
+                            progressHelper.Callback?.Invoke((ulong)e.Downloaded);
                         };
 
                         if (String.Equals(_pathtype, "File", StringComparison.OrdinalIgnoreCase))

--- a/Source/PoshSSH/PoshSSH/GetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/GetScpItem.cs
@@ -69,17 +69,6 @@ namespace SSH
             set { _newname = value; }
         }
 
-        // Supress progress bar.
-        private bool _noProgress = false;
-        [Parameter(Mandatory = false,
-            ValueFromPipelineByPropertyName = true,
-            HelpMessage = "Do not show upload progress.")]
-        public SwitchParameter NoProgress
-        {
-            get { return _noProgress; }
-            set { _noProgress = value; }
-        }
-
         private string _pathTransformation = "none";
         [Parameter(Mandatory = false,
             ValueFromPipelineByPropertyName = false,

--- a/Source/PoshSSH/PoshSSH/GetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/GetScpItem.cs
@@ -133,17 +133,19 @@ namespace SSH
 
                         string curName = "";
                         var progressHelper = new OperationProgressHelper(this, "Download", curName, 0, 1);
-                        client.Downloading += delegate (object sender, ScpDownloadEventArgs e)
+                        if (progressHelper.IsProgressVisible)
                         {
-                            if (e.Filename != curName)
+                            client.Downloading += delegate (object sender, ScpDownloadEventArgs e)
                             {
-                                progressHelper.Complete();
-                                curName = e.Filename;
-                                progressHelper = new OperationProgressHelper(this, "Download", curName, e.Size, 1);
-                            }
-                            progressHelper.Callback?.Invoke((ulong)e.Downloaded);
-                        };
-
+                                if (e.Filename != curName)
+                                {
+                                    progressHelper.Complete();
+                                    curName = e.Filename;
+                                    progressHelper = new OperationProgressHelper(this, "Download", curName, e.Size, 1);
+                                }
+                                progressHelper.Callback?.Invoke((ulong)e.Downloaded);
+                            };
+                        }
                         if (String.Equals(_pathtype, "File", StringComparison.OrdinalIgnoreCase))
                         {
                             WriteVerbose("File name " + localname);

--- a/Source/PoshSSH/PoshSSH/GetSftpItem.cs
+++ b/Source/PoshSSH/PoshSSH/GetSftpItem.cs
@@ -75,17 +75,6 @@ namespace SSH
             set { _localpath = value; }
         }
 
-        // Supress progress bar.
-        private bool _noProgress = false;
-        [Parameter(Mandatory = false,
-            ValueFromPipelineByPropertyName = true,
-            HelpMessage = "Do not show upload progress.")]
-        public SwitchParameter NoProgress
-        {
-            get { return _noProgress; }
-            set { _noProgress = value; }
-        }
-
         /// <summary>
         /// If the local file exists overwrite it.
         /// </summary>

--- a/Source/PoshSSH/PoshSSH/GetSftpItem.cs
+++ b/Source/PoshSSH/PoshSSH/GetSftpItem.cs
@@ -171,33 +171,10 @@ namespace SSH
                                 var fileFullPath = $"{@localfullPath}{System.IO.Path.DirectorySeparatorChar}{dirName}";
 
                                 var present = Directory.Exists(fileFullPath);
-                                if ((present & _overwrite) || (!present))
+                                if (!present || _overwrite)
                                 {
-                                    var res = new Action<ulong>(rs =>
-                                    {
-                                        if (attribs.Size != 0)
-                                        {
-                                            var percent = (int)((((double)rs) / attribs.Size) * 100.0);
-                                            if (percent % 10 == 0)
-                                            {
-                                                // This should prevent the progress message from being stuck on the screen.
-                                                if (percent == 100)
-                                                {
-                                                    return;
-                                                }
-
-                                                var progressRecord = new ProgressRecord(1,
-                                                "Downloading " + remotepath,
-                                                String.Format("{0} Bytes Downloaded of {1}", rs, attribs.Size))
-                                                { PercentComplete = percent };
-
-                                                Host.UI.WriteProgress(1, progressRecord);
-                                            }
-
-                                        }
-                                    });
                                     Directory.CreateDirectory(fileFullPath);
-                                    DownloadDirectory(sftpSession.Session, remotepath, fileFullPath, _skipsymlink, res);
+                                    DownloadDirectory(sftpSession.Session, remotepath, fileFullPath, _skipsymlink);
                                 }
                                 else
                                 {
@@ -212,59 +189,35 @@ namespace SSH
                             else if (attribs.IsRegularFile)
                             {
                                 var fileName = new FileInfo(remotepath).Name;
-                                // Setup Action object for showing download progress.
-                                var res = new Action<ulong>(rs =>
-                                {
-                                    if (attribs.Size != 0)
-                                    {
-                                        var percent = (int)((((double)rs) / attribs.Size) * 100.0);
-                                        if (percent % 10 == 0)
-                                        {
-                                            // This should prevent the progress message from being stuck on the screen.
-                                            if (percent == 100)
-                                            {
-                                                return;
-                                            }
-
-                                            var progressRecord = new ProgressRecord(1,
-                                            "Downloading: " + fileName,
-                                            String.Format("{0} Bytes Downloaded of {1}", rs, attribs.Size))
-                                            { PercentComplete = percent };
-
-                                            Host.UI.WriteProgress(1, progressRecord);
-                                        }
-
-                                    }
-                                });
 
                                 var fileFullPath = $"{@localfullPath}{System.IO.Path.DirectorySeparatorChar}{fileName}";
 
                                 var present = File.Exists(fileFullPath);
 
-                                if ((present & _overwrite) || (!present))
+                                if (!present || _overwrite)
                                 {
-                                    var localstream = File.Create(fileFullPath);
-                                    try
+                                    using (var localstream = File.Create(fileFullPath))
                                     {
-                                        WriteVerbose($"Downloading: {remotepath}");
-                                        sftpSession.Session.DownloadFile(remotepath, localstream, res);
-                                        localstream.Close();
-                                        var progressRecord = new ProgressRecord(1,
-                                            "Downloading: " + remotepath,
-                                            String.Format("{0} Bytes Downloaded of {1}",attribs.Size, attribs.Size))
-                                        { PercentComplete = 100 };
-
-                                        WriteProgress(progressRecord);
-                                    }
-                                    catch
-                                    {
-                                        localstream.Close();
-                                        var ex = new SftpPermissionDeniedException($"Unable to download {remotepath} from host.");
-                                        WriteError(new ErrorRecord(
-                                            ex,
-                                           $"Unable to download {remotepath} from host.",
-                                            ErrorCategory.InvalidOperation,
-                                            sftpSession));
+                                        try
+                                        {
+                                            WriteVerbose($"Downloading: {remotepath}");
+                                            var progressHelper = new OperationProgressHelper(this, "Download", remotepath, attribs.Size, 1);
+                                            sftpSession.Session.DownloadFile(remotepath, localstream, progressHelper.Callback);
+                                            progressHelper.Complete();
+                                        }
+                                        catch
+                                        {
+                                            var ex = new SftpPermissionDeniedException($"Unable to download {remotepath} from host.");
+                                            WriteError(new ErrorRecord(
+                                                ex,
+                                               $"Unable to download {remotepath} from host.",
+                                                ErrorCategory.InvalidOperation,
+                                                sftpSession));
+                                        }
+                                        finally
+                                        {
+                                            localstream.Close();
+                                        }
                                     }
                                 }
                                 else
@@ -309,14 +262,14 @@ namespace SSH
             }
         }
 
-        private void DownloadDirectory(SftpClient client, string source, string localPath, bool skipsymlink, Action<ulong> progress)
+        private void DownloadDirectory(SftpClient client, string source, string localPath, bool skipsymlink)
         {
             var files = client.ListDirectory(source);
             foreach (var file in files)
             {
                 if (!file.IsDirectory && !file.IsSymbolicLink)
                 {
-                    DownloadFile(client, file, localPath, progress);
+                    DownloadFile(client, file, localPath);
                 }
                 else if (file.IsSymbolicLink)
                 {
@@ -331,11 +284,11 @@ namespace SSH
                         {
                             var localFullPath = System.IO.Path.Combine(localPath, file.Name);
                             var dir = Directory.CreateDirectory(localFullPath);
-                            DownloadDirectory(client, file.FullName, dir.FullName, skipsymlink, progress);
+                            DownloadDirectory(client, file.FullName, dir.FullName, skipsymlink);
                         }
                         else if (attribs.IsRegularFile)
                         {
-                            DownloadFile(client, file, localPath, progress);
+                            DownloadFile(client, file, localPath);
                         }
                     }
 
@@ -344,18 +297,21 @@ namespace SSH
                 {
                     var localFullPath = System.IO.Path.Combine(localPath, file.Name);
                     var dir = Directory.CreateDirectory(localFullPath);
-                    DownloadDirectory(client, file.FullName, dir.FullName, skipsymlink, progress);
+                    DownloadDirectory(client, file.FullName, dir.FullName, skipsymlink);
                 }
             }
         }
 
-        private void DownloadFile(SftpClient client, SftpFile file, string localDirectory, Action<ulong> progress)
+        private void DownloadFile(SftpClient client, SftpFile file, string localDirectory)
         {
             WriteVerbose($"Downloading {file.FullName}");
             var localFullPath = System.IO.Path.Combine(localDirectory, file.Name);
+            // Setup Action object for showing download progress.
+            var progressHelper = new OperationProgressHelper(this, "Download", file.Name, file.Length, 1);
             using (Stream fileStream = File.Create(localFullPath))
             {
-                client.DownloadFile(file.FullName, fileStream, progress);
+                client.DownloadFile(file.FullName, fileStream, progressHelper.Callback);
+                progressHelper.Complete();
             }
         }
     }

--- a/Source/PoshSSH/PoshSSH/OperationProgressHelper.cs
+++ b/Source/PoshSSH/PoshSSH/OperationProgressHelper.cs
@@ -28,7 +28,7 @@ namespace SSH
             };
             if (cmdlet.SessionState.PSVariable.GetValue("ProgressPreference", "Continue").ToString().Equals("SilentlyContinue", StringComparison.OrdinalIgnoreCase))
             {
-                Callback = new Action<ulong>(bytes => { });
+                Callback = null;
                 Complete = () => {};
             }
             else

--- a/Source/PoshSSH/PoshSSH/OperationProgressHelper.cs
+++ b/Source/PoshSSH/PoshSSH/OperationProgressHelper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SSH
+{
+    internal class OperationProgressHelper
+    {
+        public Action<ulong> Callback { get; }
+        public Action Complete { get; }
+
+        public OperationProgressHelper(PSCmdlet cmdlet, string Operation, string FileName, long FileLength, int ActivityId = 1, int ParentActivityId = -1)
+        {
+            var activity = Operation + "ing " + FileName;
+            var operation = Operation.ToLower();
+            int prev_percent = 0;
+            DateTime start_time = DateTime.Now;
+            var progressRecord = new ProgressRecord(ActivityId, activity, " ")
+            {
+                PercentComplete = 0,
+                SecondsRemaining = -1,
+                ParentActivityId = ParentActivityId,
+            };
+            if (cmdlet.SessionState.PSVariable.GetValue("ProgressPreference", "Continue").ToString().Equals("SilentlyContinue", StringComparison.OrdinalIgnoreCase))
+            {
+                Callback = new Action<ulong>(bytes => { });
+                Complete = () => {};
+            }
+            else
+            {
+                Callback = new Action<ulong>(bytes =>
+                {
+                    var percent = (int)((double)bytes / FileLength * 100);
+                    var time = DateTime.Now;
+                    var time_passed_total = (time - start_time).TotalSeconds;
+                    // change progress only if it really changed and the process lasted more than 1 second
+                    if (prev_percent != percent && time_passed_total > 1)
+                    {
+                        // average speed
+                        var speed = bytes / time_passed_total / 1024;
+                        // instant speed
+                        //var speed = ((double)bytes - prev_bytes) / (time - prev_time).TotalSeconds / 1024;
+                        var remain = ((double)FileLength - bytes) / bytes * time_passed_total;
+
+                        progressRecord.PercentComplete = percent;
+                        progressRecord.SecondsRemaining = (int)remain;
+                        progressRecord.StatusDescription = string.Format("{0} Bytes {1}ed of {2}, speed {3:f3} Kb/sec", bytes, operation, FileLength, speed);
+                        cmdlet.Host.UI.WriteProgress(1, progressRecord);
+                    }
+                    prev_percent = percent;
+                });
+                Complete = () =>
+                {
+                    progressRecord.PercentComplete = 100;
+                    progressRecord.RecordType = ProgressRecordType.Completed;
+                    cmdlet.Host.UI.WriteProgress(1, progressRecord);
+                };
+            }
+        }        
+    }
+}

--- a/Source/PoshSSH/PoshSSH/OperationProgressHelper.cs
+++ b/Source/PoshSSH/PoshSSH/OperationProgressHelper.cs
@@ -11,6 +11,7 @@ namespace SSH
 {
     internal class OperationProgressHelper
     {
+        public bool IsProgressVisible { get; }
         public Action<ulong> Callback { get; }
         public Action Complete { get; }
 
@@ -26,7 +27,8 @@ namespace SSH
                 SecondsRemaining = -1,
                 ParentActivityId = ParentActivityId,
             };
-            if (cmdlet.SessionState.PSVariable.GetValue("ProgressPreference", "Continue").ToString().Equals("SilentlyContinue", StringComparison.OrdinalIgnoreCase))
+            IsProgressVisible = ! cmdlet.SessionState.PSVariable.GetValue("ProgressPreference", "Continue").ToString().Equals("SilentlyContinue", StringComparison.OrdinalIgnoreCase);
+            if (! IsProgressVisible)
             {
                 Callback = null;
                 Complete = () => {};

--- a/Source/PoshSSH/PoshSSH/PoshSSH.csproj
+++ b/Source/PoshSSH/PoshSSH/PoshSSH.csproj
@@ -63,6 +63,7 @@
     <Compile Include="NewMemoryStore.cs" />
     <Compile Include="NewSessionBase.cs" />
     <Compile Include="NewSshJsonStore.cs" />
+    <Compile Include="OperationProgressHelper.cs" />
     <Compile Include="PoshSessionType.cs" />
     <Compile Include="SetScpItem.cs" />
     <Compile Include="SetSftpFile.cs" />

--- a/Source/PoshSSH/PoshSSH/SetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/SetScpItem.cs
@@ -147,7 +147,7 @@ namespace SSH
                                     curName = e.Filename;
                                     progressHelper = new OperationProgressHelper(this, "Upload", curName, e.Size, 1);
                                 }
-                                progressHelper.Callback((ulong)e.Uploaded);
+                                progressHelper.Callback?.Invoke((ulong)e.Uploaded);
                             };
 
                             if (fil.Exists)

--- a/Source/PoshSSH/PoshSSH/SetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/SetScpItem.cs
@@ -60,17 +60,6 @@ namespace SSH
             set { _newname = value; }
         }
 
-        // Supress progress bar.
-        private bool _noProgress = false;
-        [Parameter(Mandatory = false,
-            ValueFromPipelineByPropertyName = true,
-            HelpMessage = "Do not show upload progress.")]
-        public SwitchParameter NoProgress
-        {
-            get { return _noProgress; }
-            set { _noProgress = value; }
-        }
-
         private string _pathTransformation = "none";
         [Parameter(Mandatory = false,
             ValueFromPipelineByPropertyName = false,

--- a/Source/PoshSSH/PoshSSH/SetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/SetScpItem.cs
@@ -139,16 +139,19 @@ namespace SSH
                             WriteVerbose("Destination: " + remoteFullpath);
                             var progressHelper = new OperationProgressHelper(this, "Upload", "", 0, 1);
                             string curName = "";
-                            client.Uploading += delegate (object sender, ScpUploadEventArgs e)
+                            if (progressHelper.IsProgressVisible)
                             {
-                                if (e.Filename != curName)
+                                client.Uploading += delegate (object sender, ScpUploadEventArgs e)
                                 {
-                                    progressHelper.Complete();
-                                    curName = e.Filename;
-                                    progressHelper = new OperationProgressHelper(this, "Upload", curName, e.Size, 1);
-                                }
-                                progressHelper.Callback?.Invoke((ulong)e.Uploaded);
-                            };
+                                    if (e.Filename != curName)
+                                    {
+                                        progressHelper.Complete();
+                                        curName = e.Filename;
+                                        progressHelper = new OperationProgressHelper(this, "Upload", curName, e.Size, 1);
+                                    }
+                                    progressHelper.Callback?.Invoke((ulong)e.Uploaded);
+                                };
+                            }
 
                             if (fil.Exists)
                             {

--- a/Source/PoshSSH/PoshSSH/SetScpItem.cs
+++ b/Source/PoshSSH/PoshSSH/SetScpItem.cs
@@ -104,39 +104,7 @@ namespace SSH
                                 break;
                 
                         }
-                        var _progresspreference = (ActionPreference)this.SessionState.PSVariable.GetValue("ProgressPreference");
-                        if (_noProgress == false)
-                        {
-                            var counter = 0;
-                            // Print progess of download.
 
-                            client.Uploading += delegate (object sender, ScpUploadEventArgs e)
-                            {
-                                if (e.Size != 0)
-                                {
-                                    counter++;
-
-                                    if (counter > 900)
-                                    {
-                                        var percent = Convert.ToInt32((e.Uploaded * 100) / e.Size);
-
-                                        if (percent == 100)
-                                        {
-                                            return;
-                                        }
-
-                                        var progressRecord = new ProgressRecord(1,
-                                            "Uploading " + e.Filename,
-                                            String.Format("{0} Bytes Uploaded of {1}",
-                                            e.Uploaded, e.Size))
-                                        { PercentComplete = percent };
-
-                                        Host.UI.WriteProgress(1, progressRecord);
-                                        counter = 0;
-                                    }
-                                }
-                            };
-                        }
                         WriteVerbose("Connection successful");
 
                         ProviderInfo provider;
@@ -169,6 +137,19 @@ namespace SSH
                             }
 
                             WriteVerbose("Destination: " + remoteFullpath);
+                            var progressHelper = new OperationProgressHelper(this, "Upload", "", 0, 1);
+                            string curName = "";
+                            client.Uploading += delegate (object sender, ScpUploadEventArgs e)
+                            {
+                                if (e.Filename != curName)
+                                {
+                                    progressHelper.Complete();
+                                    curName = e.Filename;
+                                    progressHelper = new OperationProgressHelper(this, "Upload", curName, e.Size, 1);
+                                }
+                                progressHelper.Callback((ulong)e.Uploaded);
+                            };
+
                             if (fil.Exists)
                             {
                                 client.Upload(fil, remoteFullpath);
@@ -177,6 +158,7 @@ namespace SSH
                             {
                                 client.Upload(dirinfo, remoteFullpath);
                             }
+                            progressHelper.Complete();
 
                             client.Disconnect();
                         }


### PR DESCRIPTION
Common progress bar visualization for **Get/Set-xxxItem**

_WIP_: Is `-NoProgress` switch still needed somewhere ?

Now new progress  bar obey `$ProgressPreference`, so switch is not used

It should be removed or expanded to all mentioned cmdlets. Now it absent in Set-SftpItem