### PR TITLE
Call keystore.OnKeyUpdated() only on real key update

### DIFF
--- a/Source/PoshSSH/PoshSSH/NewSessionBase.cs
+++ b/Source/PoshSSH/PoshSSH/NewSessionBase.cs
@@ -328,9 +328,12 @@ namespace SSH
                             }
                             if (e.CanTrust)
                             {
-                                if (!KnownHost.SetKey(computer1, e.HostKeyName, fingerPrint))
+                                if (KnownHost.SetKey(computer1, e.HostKeyName, fingerPrint))
                                 {
-                                    Host.UI.WriteWarningLine("Host key is not saved to store.");
+                                    Host.UI.WriteVerboseLine(string.Format("Set host key for {0} to {1}", computer1, fingerPrint));
+                                }
+                                else {
+                                    Host.UI.WriteVerboseLine("Host key is not updated in store.");
                                 }
                             }
 

--- a/Source/PoshSSH/PoshSSH/Stores/MemoryStore.cs
+++ b/Source/PoshSSH/PoshSSH/Stores/MemoryStore.cs
@@ -32,10 +32,16 @@ namespace SSH.Stores
                 HostKeyName = HostKeyName,
                 Fingerprint = Fingerprint,
             };
+            bool skip_update = false;
             HostKeys.AddOrUpdate(Host, hostData, (key, oldValue) => {
+                skip_update = oldValue.HostKeyName.Equals(hostData.HostKeyName, StringComparison.OrdinalIgnoreCase) &&
+                        oldValue.Fingerprint.Equals(hostData.Fingerprint, StringComparison.OrdinalIgnoreCase);
                 return hostData;
             });
-            return OnKeyUpdated();
+            if (skip_update)
+                return true;
+            else
+                return OnKeyUpdated();
         }
         /// <summary>
         /// If IStore is updated this can be the implementation


### PR DESCRIPTION
solves #457
but only if all keys already exists in store.

If we need to remove possible errors while file saving there is need more working on it.

Changed message from warning to verbose because really this is not error, or may be it also need be reworked ?