### PR TITLE
use fixed ssh.net

### DIFF
--- a/Source/PoshSSH/PoshSSH.Core/PoshSSH.Core.csproj
+++ b/Source/PoshSSH/PoshSSH.Core/PoshSSH.Core.csproj
@@ -37,7 +37,7 @@
       <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #537 

@darkoperator  SSH.NET v2023.0.0 has the fix, updating the reference I see the PoshSSH.Core compiles fine and works as expected in my tests against 8.8 SSHD with `sha-rsa` disabled. I can add the dlls to the PR, but thought you may want to do that yourself.