### PR TITLE
Remove unused parameter from ReadAllLines call

### DIFF
--- a/Posh-SSH/Posh-SSH.psm1
+++ b/Posh-SSH/Posh-SSH.psm1
@@ -2235,7 +2235,7 @@ function Get-SFTPContent
 
                     'MultiLine' {
 
-                        $session.session.ReadAllLines($Path, $Value, $ContentEncoding)
+                        $session.session.ReadAllLines($Path, $ContentEncoding)
 
                     }
                     Default {$session.session.ReadAllBytes($Path)}


### PR DESCRIPTION
Get-SFTPContent fails when using the -ContentType MultiLine parameter. The [ValidateSet] correctly includes 'MultiLine', but the function's internal logic incorrectly attempts to use an undefined $Value variable when calling the underlying .ReadAllLines() method.